### PR TITLE
add csrf token so POST requests complete

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -37,6 +37,7 @@
 </head>
 
 <body class="light">
+  {% csrf_token %}
   <div id="top_menu">
   </div>
   <div id="leftbar">


### PR DESCRIPTION
This may not be necessary if we implement what I talked about with giving apps their own key, but we haven't done that yet, so I need to be able to get the CSRF token to submit forms (or I misunderstand how the forms are supposed to be submitted)