### PR TITLE
Install packages in dockerfile to allow caching of intermediate image

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,10 +1,15 @@
 # pull the base image
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-buster as baseimage
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
+COPY install/requirements/pip_requirements.txt requirements.txt
+RUN apt-get update && apt-get install git procps python3-psycopg2 -y
+RUN pip3 install -r requirements.txt
+
+FROM baseimage
 RUN mkdir -p /opt/flockpocket
 WORKDIR /opt/flockpocket
 COPY . /opt/flockpocket

--- a/install/install.py
+++ b/install/install.py
@@ -21,10 +21,10 @@ if args.full:
 code = run(command.split()).returncode
 
 # Package Install
-print("installing packages...")
-command = "%s/packages.py" % curr_dir
-if args.full:
-    command += ' -f'
-code = run(command.split()).returncode
-if (code):
-    sys.exit(code)
+# print("installing packages...")
+# command = "%s/packages.py" % curr_dir
+# if args.full:
+#     command += ' -f'
+# code = run(command.split()).returncode
+# if (code):
+#     sys.exit(code)


### PR DESCRIPTION
This follows more typical Dockerfile convention, which allows it to cache the image for faster subsequent builds.

You were right, though, in that I didn't need to keep rebuilding the image.